### PR TITLE
Update config access patterns

### DIFF
--- a/internal/cmd/clear.go
+++ b/internal/cmd/clear.go
@@ -50,7 +50,7 @@ func ClearCmd() *cobra.Command {
 }
 
 func clearCache() {
-	deleteFile(config.C.CacheFileFullPath, "Deleting cache", "Could not delete cache")
+	deleteFile(config.Get().CacheFileFullPath, "Deleting cache", "Could not delete cache")
 }
 
 func clearConfig() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
 )
 
 type Config struct {
@@ -35,13 +37,26 @@ type configFromFile struct {
 	SearchMaxDepth int `mapstructure:"search_max_depth"`
 }
 
-var C *Config = nil
+var config *Config = nil
+
+func HomeDir() string {
+	hd, err := homedir.Dir()
+	cobra.CheckErr(err)
+	return hd
+}
 
 func Filepath() string {
 	return filepath.Join(HomeDir(), JumperDirname, fmt.Sprintf("%s.%s", Filename, Type))
 }
 
-func Init() {
+func Get() Config {
+	if config == nil {
+		initialize()
+	}
+	return *config
+}
+
+func initialize() {
 	hd := HomeDir()
 
 	configDirFull := filepath.Join(hd, JumperDirname)
@@ -61,7 +76,8 @@ func Init() {
 	viper.SetDefault("search_max_depth", defaultSearchMaxDepth)
 
 	err := viper.SafeWriteConfig()
-	if _, ok := err.(viper.ConfigFileAlreadyExistsError); ok {
+	var configFileAlreadyExistsError viper.ConfigFileAlreadyExistsError
+	if errors.As(err, &configFileAlreadyExistsError) {
 		// ignore, this is ok. just means the config already exists, so
 		// we don't need to write a new one
 	} else {
@@ -80,8 +96,8 @@ func Init() {
 	err = viper.WriteConfig()
 	cobra.CheckErr(err)
 
-	// copy internalConf to C
-	C = &Config{
+	// copy internalConf to config
+	config = &Config{
 		HomeDir:        hd,
 		SearchIncludes: internalConf.SearchIncludes,
 		SearchExcludes: internalConf.SearchExcludes,
@@ -89,17 +105,56 @@ func Init() {
 		SearchMaxDepth: internalConf.SearchMaxDepth,
 	}
 
-	C.CacheFileFullPath = filepath.Join(C.HomeDir, JumperDirname, C.CacheFile)
-	C.JumperDir = filepath.Join(C.HomeDir, JumperDirname)
+	config.CacheFileFullPath = filepath.Join(config.HomeDir, JumperDirname, config.CacheFile)
+	config.JumperDir = filepath.Join(config.HomeDir, JumperDirname)
 
 	for _, pathStop := range internalConf.SearchPathStops {
 		pathStopRegexp := regexp.MustCompile(fmt.Sprintf("%s$", regexp.QuoteMeta(pathStop)))
-		C.SearchPathStops = append(C.SearchPathStops, pathStopRegexp)
+		config.SearchPathStops = append(config.SearchPathStops, pathStopRegexp)
 	}
 }
 
-func HomeDir() string {
-	hd, err := homedir.Dir()
+func (c *Config) Save() {
+	hd := HomeDir()
+
+	internalConf := c.toInternalConfig()
+
+	configDirFull := filepath.Join(hd, JumperDirname)
+	if _, err := os.Stat(configDirFull); os.IsNotExist(err) {
+		err := os.MkdirAll(configDirFull, os.ModePerm)
+		cobra.CheckErr(err)
+	}
+
+	out, err := yaml.Marshal(internalConf)
 	cobra.CheckErr(err)
-	return hd
+
+	fo, err := os.Open(Filepath())
+	cobra.CheckErr(err)
+	defer func() {
+		cobra.CheckErr(fo.Close())
+	}()
+
+	_, err = fo.Write(out)
+	cobra.CheckErr(err)
+
+	config = c
+}
+
+func (ic *configFromFile) ToConfig() Config {
+	return Config{
+		HomeDir:        HomeDir(),
+		SearchIncludes: ic.SearchIncludes,
+		SearchExcludes: ic.SearchExcludes,
+		CacheFile:      ic.CacheFile,
+		SearchMaxDepth: ic.SearchMaxDepth,
+	}
+}
+
+func (c *Config) toInternalConfig() configFromFile {
+	return configFromFile{
+		CacheFile:      c.CacheFile,
+		SearchIncludes: c.SearchIncludes,
+		SearchExcludes: c.SearchExcludes,
+		SearchMaxDepth: c.SearchMaxDepth,
+	}
 }

--- a/internal/core/app.go
+++ b/internal/core/app.go
@@ -21,7 +21,7 @@ type Application struct {
 }
 
 func (a *Application) Setup() {
-	isStale, err := isCacheStale(config.C.CacheFileFullPath)
+	isStale, err := isCacheStale(config.Get().CacheFileFullPath)
 	if os.IsNotExist(err) {
 		a.Analyze()
 	} else {
@@ -35,17 +35,17 @@ func (a *Application) Setup() {
 }
 
 func (a *Application) Analyze() {
-	excludeRegex := lib.RegexpJoinPartsOr(config.C.SearchExcludes)
+	excludeRegex := lib.RegexpJoinPartsOr(config.Get().SearchExcludes)
 
 	var projectDirs []string
 	var wg sync.WaitGroup
 
 	counter := 0
 
-	wg.Add(len(config.C.SearchIncludes))
+	wg.Add(len(config.Get().SearchIncludes))
 
-	for _, search := range config.C.SearchIncludes {
-		fullSearch := filepath.Join(config.C.HomeDir, search)
+	for _, search := range config.Get().SearchIncludes {
+		fullSearch := filepath.Join(config.Get().HomeDir, search)
 		logger.Log("analyzing path", zap.String("path", fullSearch))
 
 		go func(inclPath string) {
@@ -68,7 +68,7 @@ func (a *Application) Analyze() {
 					return filepath.SkipDir
 				}
 
-				for _, re := range config.C.SearchPathStops {
+				for _, re := range config.Get().SearchPathStops {
 					if re.MatchString(p) {
 						cleanPath := filepath.Dir(p)
 						projectDirs = append(projectDirs, cleanPath)
@@ -111,7 +111,7 @@ func (a *Application) Analyze() {
 	logger.Log("number of directories walked", zap.Int("count", counter))
 	logger.Log("projects found", zap.Int("count", len(projectDirs)))
 
-	err := writeToCache(config.C.CacheFileFullPath, projectDirs)
+	err := writeToCache(config.Get().CacheFileFullPath, projectDirs)
 	if err != nil {
 		logger.Log("failed writing to cache")
 		cobra.CheckErr(err)
@@ -133,7 +133,7 @@ func (a *Application) emitCacheUpdateEvent() {
 }
 
 func (a *Application) readFromCache() {
-	c, err := readFromCache(config.C.CacheFileFullPath)
+	c, err := readFromCache(config.Get().CacheFileFullPath)
 	if err != nil {
 		cobra.CheckErr(err)
 	}
@@ -144,7 +144,7 @@ func (a *Application) readFromCache() {
 }
 
 func canSearchDeeper(path string) bool {
-	return len(strings.Split(filepath.Dir(path), string(filepath.Separator))) <= config.C.SearchMaxDepth
+	return len(strings.Split(filepath.Dir(path), string(filepath.Separator))) <= config.Get().SearchMaxDepth
 }
 
 func NewApp() *Application {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/m-porter/jumper/internal/cmd"
 	"github.com/m-porter/jumper/internal/config"
-	"github.com/spf13/cobra"
 )
 
 // set by goreleaser ldflags at build time
@@ -21,8 +20,6 @@ var date = "development"
 var builtBy = "development"
 
 func main() {
-	cobra.OnInitialize(config.Init)
-
 	rootCmd := cmd.RootCmd(cmd.RootCmdOptions{
 		Version: version,
 		Commit:  commit,
@@ -34,4 +31,8 @@ func main() {
 		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+}
+
+func init() {
+	config.Get()
 }


### PR DESCRIPTION
Changes:
* Replaces `config.C` config access with `config.Get()`
* Adds `(*Config) Save()` function which persists config changes and updates what is returned from `config.Get()`
    ```go
    // (*Config) Save() example
    conf := config.Get()
    conf.SearchMaxDepth = 4
    conf.Save()

    conf = config.Get()
    // conf.SearchMaxDepth is now 4
    ```