### PR TITLE
Use LineIndicator from config in the TUI

### DIFF
--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -18,9 +18,9 @@ func initIndicators(indicator string) {
 
 var (
 	// https://catppuccin.com/palette/
-	colorSurface1 = lipgloss.AdaptiveColor{
-		Light: "#bcc0cc",
-		Dark:  "#45475a",
+	colorSurface0 = lipgloss.AdaptiveColor{
+		Light: "#ccd0da",
+		Dark:  "#313244",
 	}
 	colorMaroon = lipgloss.AdaptiveColor{
 		Light: "#e64553",
@@ -34,15 +34,15 @@ var (
 		Light: "#4c4f69",
 		Dark:  "#cdd6f4",
 	}
-	colorSubtext0 = lipgloss.AdaptiveColor{
-		Light: "#6c6f85",
-		Dark:  "#a6adc8",
+	colorOverlay2 = lipgloss.AdaptiveColor{
+		Light: "#7c7f93",
+		Dark:  "#9399b2",
 	}
 
-	bgGrayStyle          = lipgloss.NewStyle().Background(colorSurface1).Bold(true)
-	indicatorStyle       = lipgloss.NewStyle().Bold(true).Foreground(colorMaroon).Background(colorSurface1)
-	detailDimStyleBgGray = lipgloss.NewStyle().Bold(true).Foreground(colorSubtext0).Background(colorSurface1)
-	detailDimStyle       = lipgloss.NewStyle().Foreground(colorSubtext0)
+	bgGrayStyle          = lipgloss.NewStyle().Background(colorSurface0).Bold(true)
+	indicatorStyle       = lipgloss.NewStyle().Bold(true).Foreground(colorMaroon).Background(colorSurface0)
+	detailDimStyleBgGray = lipgloss.NewStyle().Bold(true).Foreground(colorOverlay2).Background(colorSurface0)
+	detailDimStyle       = lipgloss.NewStyle().Foreground(colorOverlay2)
 	inputArrowStyle      = lipgloss.NewStyle().Bold(true).Foreground(colorLavender)
 	textStyle            = lipgloss.NewStyle().Foreground(colorText)
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -7,8 +7,16 @@ import (
 )
 
 var (
-	lineIndicator = "❯"
+	selectedRowIndicatorPart string
+	inputIndicatorPart       string
+)
 
+func initIndicators(indicator string) {
+	selectedRowIndicatorPart = indicatorStyle.Render(indicator)
+	inputIndicatorPart = inputArrowStyle.Render(indicator)
+}
+
+var (
 	// https://catppuccin.com/palette/
 	colorSurface1 = lipgloss.AdaptiveColor{
 		Light: "#bcc0cc",
@@ -38,9 +46,7 @@ var (
 	inputArrowStyle      = lipgloss.NewStyle().Bold(true).Foreground(colorLavender)
 	textStyle            = lipgloss.NewStyle().Foreground(colorText)
 
-	selectedRowIndicatorPart = indicatorStyle.Render(lineIndicator)
-	inputIndicatorPart       = inputArrowStyle.Render(lineIndicator)
-	beamPart                 = bgGrayStyle.Render(" ")
+	beamPart = bgGrayStyle.Render(" ")
 )
 
 type listStyle int

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/m-porter/jumper/internal/config"
 	"github.com/m-porter/jumper/internal/lib"
 	"github.com/m-porter/jumper/internal/logger"
 
@@ -196,6 +197,8 @@ func (m *model) toggleListStyle() {
 }
 
 func Run(opts Options) (string, error) {
+	initIndicators(config.Get().LineIndicator)
+
 	app := core.NewApp()
 
 	m := &model{


### PR DESCRIPTION
## Summary

- Replaces the hard-coded `lineIndicator = "❯"` in `styles.go` with an `initIndicators()` function that renders the indicator parts once at startup using the value from config
- `Run()` in `tui.go` now calls `initIndicators(config.Get().LineIndicator)` before starting the program
- Also updates TUI colors to use `Surface0` and `Overlay2` from the Catppuccin palette