### PR TITLE
Make SearchMaxDepth relative to the search include root

### DIFF
--- a/internal/core/app.go
+++ b/internal/core/app.go
@@ -81,7 +81,7 @@ func (a *Application) Analyze() {
 					}
 				}
 
-				if !canSearchDeeper(p) {
+				if !canSearchDeeper(p, inclPath) {
 					//SkipDir to tell the walker to not go any further
 					return filepath.SkipDir
 				}
@@ -143,8 +143,13 @@ func (a *Application) readFromCache() {
 	}
 }
 
-func canSearchDeeper(path string) bool {
-	return len(strings.Split(filepath.Dir(path), string(filepath.Separator))) <= config.Get().SearchMaxDepth
+func canSearchDeeper(path, inclPath string) bool {
+	rel, err := filepath.Rel(inclPath, path)
+	if err != nil {
+		return false
+	}
+	depth := len(strings.Split(rel, string(filepath.Separator)))
+	return depth <= config.Get().SearchMaxDepth
 }
 
 func NewApp() *Application {


### PR DESCRIPTION
## Summary

- `canSearchDeeper` previously counted total path segments in the absolute path, making `SearchMaxDepth` meaningless as a user-facing config value
- Now computes depth via `filepath.Rel(inclPath, path)`, so `SearchMaxDepth = 1` means 1 level below the search include root (e.g. `~/development/my-project`) rather than 1 total path segment